### PR TITLE
fix: undefined local variable or method `command' 

### DIFF
--- a/lib/umu/generators/benchmark_maker.rb
+++ b/lib/umu/generators/benchmark_maker.rb
@@ -13,6 +13,7 @@ module BenchmarkMaker
       confirm_content = '上記コマンドを実行しますか？'
       run_command = Umu::Selector.single_choice(confirm_content)
       cover(1)
+      command = command('benchmark', benchmark_name)
       puts confirm_content + (run_command ? 'はい' : 'いいえ')
       system(command) if run_command
       true


### PR DESCRIPTION
fix: bug
```
gems/umu-0.1.3/lib/umu/generators/benchmark_maker.rb:16:in `generator': undefined local variable or method `command' for BenchmarkMaker:Module (NameError)

      system(command) if run_command
             ^^^^^^^
```
Thanks! @j-miyake